### PR TITLE
docs: Add Unruggable Meme slink

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ We welcome contributions from the community! If you know of a cool Slink that's 
 
 ## How to Implement a Slink
 
+### Considerations
+
+Please note that Twitter Slinks are not scrollable. If the application requires scrolling, you can do it using wrapping your body in a `div` with `overflow: auto`.
+
+```css
+html, body {
+  overflow: hidden;
+  height: 100%;
+}
+
+#root {
+  overflow: auto;
+  height: 100%;
+}
+```
+
 ### Implement Twitter Card Metadata
 
 Add the following meta tags to your main app's HTML `<head>`:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Here's a list of some cool Slinks on Starknet:
   * Live Slink Tweet: [https://x.com/Flex_strk/status/1816460243616035061](https://x.com/Flex_strk/status/1816460243616035061)
   * Official Application Website: [hyperflex.market](https://hyperflex.market/)
 
+* **Unruggable Meme**
+  * Live Slink Tweet: [https://x.com/TrueTiem/status/1816462834508738720](https://x.com/TrueTiem/status/1816462834508738720)
+  * Official Application Website: [unruggable.meme](https://unruggable.meme/)
+
 ## Contributing
 
 We welcome contributions from the community! If you know of a cool Slink that's not on the list, feel free to submit a pull request.


### PR DESCRIPTION
I've added Unrugabble Meme slink, but I think the tweet should come from the official [@UnrugMemec0in](https://x.com/UnrugMemec0in) account.

The slink currently is not scrollable, a PR is waiting to resolve this and for the official slink support.

- keep-starknet-strange/unruggable.meme#270